### PR TITLE
修正 testing.md 607 行锚点遗漏的问题

### DIFF
--- a/content/testing.md
+++ b/content/testing.md
@@ -604,7 +604,7 @@ if (Meteor.isClient) {
 
 这里需要注意：
 
- - 在运行之前，每个测试都会使用 `generateData` helper 来设置它们各自所需要的数据（参见[为集成测试创建数据]这一部分来获得更多信息），然后跳转到首页。
+ - 在运行之前，每个测试都会使用 `generateData` helper 来设置它们各自所需要的数据（参见[为集成测试创建数据](#creating-integration-test-data)这一部分来获得更多信息），然后跳转到首页。
 
  - 尽管 Flow Router 不使用完成后的回调，我们仍然可以使用 `Tracker.afterFlush` 来等待它全部的响应式结果完成。
 


### PR DESCRIPTION
<!--
🙌 感谢你提交这个 PR，但是我们希望您先自我检查一下，以减轻 review 的工作量，方便我们更快合并 😃
-->

TODO:
- [x] 根据 [README.md](https://github.com/ourmeteor/guide-zh/blob/master/README.md) 检查行文格式，尤其注意：
  - [x] 中西文间空格，标点与西文无需空格。
  - [x] 使用方引号（「『』」）而不是弯引号。
  - [x] 一致使用全角标点，而不是混用，保留的英文原句内除外。
- [x] 翻译所有代码内的注释。
- [x] 空行形式与原文统一。
- [x] 根据[术语表](https://github.com/ourmeteor/guide-zh/wiki/%E6%9C%AF%E8%AF%AD%E8%A1%A8)检查专有名词用词规范性。
